### PR TITLE
chore(types): add static asset module declarations to fix TypeScript CI errors

### DIFF
--- a/src/types/static-assets.d.ts
+++ b/src/types/static-assets.d.ts
@@ -1,0 +1,34 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpeg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.gif' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.webp' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.avif' {
+  const content: string;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "next-env.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
CI was failing with TypeScript errors for static asset imports (SVG, PNG, etc.).\n\nThis PR adds:\n- src/types/static-assets.d.ts with module declarations for common image formats\n- Updates tsconfig.json to include src/**/*.d.ts\n\nFixes TypeScript errors like 'Cannot find module public/assets/...' in CI.