### PR TITLE
fix(jest): import next/jest.js instead of next/jest for ESM compatibility

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,4 @@
-import nextJest from 'next/jest';
+import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({ dir: './' });
 


### PR DESCRIPTION
CI tests were failing with:\n\n> Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/path/to/node_modules/next/jest'\n> Did you mean to import "next/jest.js"?\n\nThis PR fixes the Jest config import to use the correct ESM module path.